### PR TITLE
fix startup crashes and add pipewire argument

### DIFF
--- a/app.xmcl.voxelum.yaml
+++ b/app.xmcl.voxelum.yaml
@@ -9,6 +9,8 @@ command: xmcl-wrapper.sh
 
 finish-args:
   - --share=ipc
+  - --socket=wayland
+  - --nosocket=wayland
   - --socket=fallback-x11
   - --device=all
   - --share=network

--- a/app.xmcl.voxelum.yaml
+++ b/app.xmcl.voxelum.yaml
@@ -9,7 +9,6 @@ command: xmcl-wrapper.sh
 
 finish-args:
   - --share=ipc
-  - --socket=wayland
   - --socket=fallback-x11
   - --device=all
   - --share=network
@@ -22,6 +21,9 @@ finish-args:
   # Fix audio spatial positioning
   - --env=PULSE_PROP=media.role=game
   - --env=PULSE_LATENCY_MSEC=60
+
+  # Additional Audio Fix
+  - --filesystem=xdg-run/pipewire-0
 
   # Minecraft data directories
   - --filesystem=~/.minecraftx:create

--- a/app.xmcl.voxelum.yaml
+++ b/app.xmcl.voxelum.yaml
@@ -9,9 +9,7 @@ command: xmcl-wrapper.sh
 
 finish-args:
   - --share=ipc
-  - --socket=wayland
-  - --nosocket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=all
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
Fix startup crashes on minecraft versions >= 26 by removing wayland socket and relying on xwayland. (Added bonus of also fixing issues with scaling and the gui).

Add pipewire argument that fixes the issue of "audio being behind you". Tested and working on version 1.20.4 on both Ultramarine Linux and Steam Deck.